### PR TITLE
Fix Boost linking issue on Barkla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.sw[op]
+build
+extra_libs/eigen-*
+extra_libs/Eigen

--- a/Makefile.mpi
+++ b/Makefile.mpi
@@ -25,7 +25,7 @@ leonardYM: $(OBJECTS)
 include Makefile.list.mk
 
 clean:
-	-rm ./build/*.o
-	-rm ./build/*.exe
+	-rm -f ./build/*.o
+	-rm -f ./build/*.exe
 
 

--- a/Makefile.mpi
+++ b/Makefile.mpi
@@ -16,7 +16,7 @@ CPPFLAGS = $(OPTIMIZE) $(INC) -DMBE="\"$(PWD)/source/utils/MatrixBaseExtension.h
 include Makefile.obj.mk
 
 all: leonardYM
-	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -lboost_program_options
+	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -L/opt/gridware/depots/e2b91392/el7/pkg/libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8/lib -lboost_program_options
 	@echo "Compiled with NUMCOLORS: " $(nc)
 
 leonardYM: $(OBJECTS)
@@ -27,5 +27,3 @@ include Makefile.list.mk
 clean:
 	-rm -f ./build/*.o
 	-rm -f ./build/*.exe
-
-

--- a/Makefile.mth
+++ b/Makefile.mth
@@ -25,7 +25,7 @@ leonardYM: $(OBJECTS)
 include Makefile.list.mk
 
 clean:
-	-rm ./build/*.exe
-	-rm ./build/*.o
+	-rm -f ./build/*.exe
+	-rm -f ./build/*.o
 
 

--- a/Makefile.mth
+++ b/Makefile.mth
@@ -16,7 +16,7 @@ CPPFLAGS = $(OPTIMIZE) $(INC) -DMBE="\"$(PWD)/source/utils/MatrixBaseExtension.h
 include Makefile.obj.mk
 
 all: leonardYM
-	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -lboost_program_options 
+	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -L/opt/gridware/depots/e2b91392/el7/pkg/libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8/lib -lboost_program_options 
 	@echo "Compiled with NUMCOLORS: " $(nc)
 
 leonardYM: $(OBJECTS)

--- a/Makefile.mth
+++ b/Makefile.mth
@@ -16,16 +16,14 @@ CPPFLAGS = $(OPTIMIZE) $(INC) -DMBE="\"$(PWD)/source/utils/MatrixBaseExtension.h
 include Makefile.obj.mk
 
 all: leonardYM
-	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -L/opt/gridware/depots/e2b91392/el7/pkg/libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8/lib -lboost_program_options 
+	$(CPP) $(CPPFLAGS) $(OBJECTS) -o ./build/leonardYM.exe -L/opt/gridware/depots/e2b91392/el7/pkg/libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8/lib -lboost_program_options
 	@echo "Compiled with NUMCOLORS: " $(nc)
 
 leonardYM: $(OBJECTS)
 	@echo "done!"
-	
+
 include Makefile.list.mk
 
 clean:
-	-rm -f ./build/*.exe
 	-rm -f ./build/*.o
-
-
+	-rm -f ./build/*.exe

--- a/extra_libs/geteigen.sh
+++ b/extra_libs/geteigen.sh
@@ -1,3 +1,8 @@
-wget http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
-tar -xvjf 3.3.7.tar.bz2
-mv eigen-* Eigen
+v=3.3.9
+
+if [ ! -f eigen-$v.tar.bz2 ] ; then
+  wget https://gitlab.com/libeigen/eigen/-/archive/$v/eigen-$v.tar.bz2
+fi
+rm -f Eigen
+tar -xvjf eigen-$v.tar.bz2
+ln -s eigen-$v Eigen


### PR DESCRIPTION
Even though the `module add libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8` command puts the path `/opt/gridware/depots/e2b91392/el7/pkg/libs/boost/1.60.0/gcc-5.5.0+openmpi-1.10.7+python-2.7.8/lib` into my `$LD_LIBRARY_PATH`, I just found that it seems to be necessary to specify this path explicitly in the linking step in the Makefile.  That's a bit of a hack, since it's not portable to other systems, but lets me compile the unmodified code on Barkla.